### PR TITLE
Split fail/success counts after 14 for conc. stones count

### DIFF
--- a/js/enhancement.js
+++ b/js/enhancement.js
@@ -717,6 +717,8 @@ function enhance_weapon(obj, weapon_id, slot_num, random_num, existing_div) {
 
 				if (random_num <= enhancement_rank.sixteen)
 				{
+					obj[weapon_id].black_stone_weapon_total_success = obj[weapon_id].enhancement_success_count;
+					obj[weapon_id].black_stone_weapon_total_failure = obj[weapon_id].enhancement_fail_count;
 					enhancement_success(obj, existing_div, weapon_id, slot_num);
 				}
 				else

--- a/js/equipment.js
+++ b/js/equipment.js
@@ -19,10 +19,8 @@ function inventory_object() {
 	this.enhancement_success_count = 0;
 	this.enhancement_fail_count = 0;
 	this.total_enhancement_attempts = 0;
-	this.black_stone_weapon = 0;
-	this.black_stone_armor = 0;
-	this.concentrated_black_stone_weapon = 0;
-	this.concentrated_black_stone_armor = 0;
+	this.black_stone_weapon_total_success = 0;
+	this.black_stone_weapon_total_failure = 0;
 	this.empty = true;
 }
 
@@ -69,11 +67,26 @@ function imgover_inventory(img, desc) {
 	var desc_span;
 	var desc_ap = $('#' + desc).children('.total_ap');
 
-	//took the lazy way out and added a line break before and after property
-	var span_enhancement_success_count = '<span class="enhancement_success_count"> </br> Total Enhancement Success Count: ' + obj[weapon_id].enhancement_success_count + ' </span>';
-	var span_enhancement_fail_count = '<span class="enhancement_fail_count"> </br> Total Enhancement Fail Count: ' + obj[weapon_id].enhancement_fail_count + ' </span>';
-	var span_total_enhancement_count = '<span class="total_enhancement_attempts"> </br> Total Enhancement Count: ' + obj[weapon_id].total_enhancement_attempts + ' </span>';
-
+	//if weapon enhancement rank greater than 15, display new counts
+	//for concentrated blackstones, and a separate count for regular
+	//black stone success/failure
+	if (obj[weapon_id].enhance_rank >= 15)
+	{
+		var span_enhancement_success_count = '<span class="enhancement_success_count"> </br> Total Enhancement Success Count: ' + 
+											 obj[weapon_id].enhancement_success_count + ' (Pre-15: ' + obj[weapon_id].black_stone_weapon_total_success + ') </span>';
+											 
+		var span_enhancement_fail_count = '<span class="enhancement_fail_count"> </br> Total Enhancement Fail Count: ' + obj[weapon_id].enhancement_fail_count + ' (Pre-15: ' + 
+										  obj[weapon_id].black_stone_weapon_total_failure + ') </span>';
+										  
+		var span_total_enhancement_count = '<span class="total_enhancement_attempts"> </br> Total Enhancement Count: ' + obj[weapon_id].total_enhancement_attempts + ' </span>';
+	}
+	else
+	{
+		var span_enhancement_success_count = '<span class="enhancement_success_count"> </br> Total Enhancement Success Count: ' + obj[weapon_id].enhancement_success_count + ' </span>';
+		var span_enhancement_fail_count = '<span class="enhancement_fail_count"> </br> Total Enhancement Fail Count: ' + obj[weapon_id].enhancement_fail_count + ' </span>';
+		var span_total_enhancement_count = '<span class="total_enhancement_attempts"> </br> Total Enhancement Count: ' + obj[weapon_id].total_enhancement_attempts + ' </span>';
+	}
+	
 	temp_tooltip_ap = desc_ap.text();
 
 	$('#' + desc).append(span_enhancement_success_count);
@@ -87,7 +100,7 @@ function imgover_inventory(img, desc) {
 		desc_span = $('#' + desc).children('.blue_weapon_name');
 		temp_tooltip_name = $('#' + desc).children('.blue_weapon_name').text();
 	}
-	//makes everything not a liverto
+	//makes everything not a liverto yellow
 	else
 	{
 		desc_span = $('#' + desc).children('.gold_weapon_name');


### PR DESCRIPTION
To simply put it, once an equipment reaches +15, I split the success/fail enhancement counts when you hover over an item so it's easier to indicate how many concentrated black stones and regular black stones you've used so far during enhancement.